### PR TITLE
in-browser-factory

### DIFF
--- a/src/rapydscript.pyj
+++ b/src/rapydscript.pyj
@@ -40,11 +40,10 @@ def splatBaselib(key, value):
         })
     })
 
-browser_env = False
-if not exports:
+browser_env = not exports
+if browser_env:
     # browser environment
     rapydscript = exports = {}
-    browser_env = True
 
 exports.parse_baselib = exports.parseBaselib = def(srcPath, beautify):
     try:
@@ -173,10 +172,3 @@ exports.ImportError = utils.ImportError
 exports.ALL_KEYWORDS = tokenizer.ALL_KEYWORDS
 exports.IDENTIFIER_PAT = tokenizer.IDENTIFIER_PAT
 exports.colored = utils.colored
-
-# browser environment logic
-if  browser_env:
-    if JS('typeof define == "function"') and define.amd:
-        define([], def(): return exports;)
-    else:    
-        parent.rapydscript = exports

--- a/src/self.pyj
+++ b/src/self.pyj
@@ -56,7 +56,21 @@ module.exports = def compile_self(base_path, src_path, lib_path, start_time):
 
     for filename in compiled:
         fs.writeFileSync(path.join(lib_path, filename + '.js'), compiled[filename], "utf8")
-
-    # output 'rapydscript.js' wrapped in private scope as 'rapydscript_web.js' for safer use in browser
-    wrapped = '(function(){\n"use strict";\n' + compiled['rapydscript']  +   '\n})();'
-    fs.writeFileSync(path.join(lib_path, 'rapydscript_web.js'), wrapped, "utf8")    
+    
+    # make in-browser version  as 'rapydscript_web.js'
+    # wrap 'rapydscript.js' in the factory function to be able to get an independent clone of the compiler
+    # now we can: compiler_clone = rapydscript.factory()
+    factory =  """
+    function factory(){
+        "use strict";
+        <compiled_rapydscript>
+        exports.factory = factory;
+        return exports;
+    };
+    if ((typeof define == "function") && define.amd) define([], factory)
+    else window.rapydscript = factory();
+    """    
+    factory = factory.replace('<compiled_rapydscript>', compiled['rapydscript'])
+    # wrap all in private scope for safer use in the browser
+    wrapped = '(function(){\n"use strict";\n' + factory  +   '\n})();'
+    fs.writeFileSync(path.join(lib_path, 'rapydscript_web.js'), wrapped, "utf8")


### PR DESCRIPTION
Wrapping the compiler (rapydscript_web) in the factory function to allow to make an independent clone of the compiler in the browser